### PR TITLE
Normalizes headings and direct children

### DIFF
--- a/scss/pack/seed-alert/components/alert/_base.scss
+++ b/scss/pack/seed-alert/components/alert/_base.scss
@@ -15,4 +15,20 @@
   color: _get($__default-scheme, color);
   margin-bottom: $seed-alert-margin-bottom;
   padding: $seed-alert-padding;
+
+  // Normalize direct child elements
+  > * {
+    // Quietly removes the bottom margin of the last child element
+    // This is to ensure the alert has desirable padding/spacing for the
+    // majority of use cases.
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  // Normalize the color of headings
+  // By default, this heading selectors match the color of text.
+  h1, h2, h3, h4, h5, h6 {
+    color: _get($__default-scheme, color);
+  }
 }

--- a/scss/pack/seed-alert/components/alert/states/_states.scss
+++ b/scss/pack/seed-alert/components/alert/states/_states.scss
@@ -5,7 +5,6 @@
 @import "pack/seed-dash/_index";
 @import "pack/seed-states/config";
 
-
 @each $key, $values in $seed-states-colors {
   $__alert-state-class: ".#{$key}";
 
@@ -17,5 +16,11 @@
     background-color: _get($values, background-color);
     box-shadow: inset $seed-alert-accent-width 0 0 0 _get($values, border-color);
     color: _get($values, color);
+
+    // Normalize the color of headings
+    // By default, this heading selectors match the color of text.
+    h1, h2, h3, h4, h5, h6 {
+      color: _get($values, color);
+    }
   }
 }


### PR DESCRIPTION
## Changes
### Normalizes the margin of direct children

The last element within an alert should have it's bottom margin removed. This is to ensure that the alert has even padding/spacing. This is the desired effect for the majority of use cases.
### Heading colours match the alert state

`h1-h6` colours have been added to the default alert as well as the various alert states. This is the desired behaviour for the majority of use cases. These styles have fairly low specificity, which makes it easier to override if necessary.

These enhancements were suggested by @nfrancis <3

Resolves: https://github.com/helpscout/seed-alert/issues/1
